### PR TITLE
修复在 ping 域名失败之后再 ping ip地址的时候会出现失败的问题。

### DIFF
--- a/ioLibrary/Internet/DNS/wizchip_dns.c
+++ b/ioLibrary/Internet/DNS/wizchip_dns.c
@@ -539,6 +539,7 @@ int8_t DNS_run(uint8_t * dns_ip, uint8_t * name, uint8_t * ip_from_dns)
 #ifdef _DNS_DEBUG_
 			printf("> DNS Server is not responding : %d.%d.%d.%d\r\n", dns_ip[0], dns_ip[1], dns_ip[2], dns_ip[3]);
 #endif
+			wizchip_close(DNS_SOCKET);
 			return 0; // timeout occurred
 		}
 		else if (ret_check_timeout == 0) {

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -102,12 +102,12 @@ static void spi_read_burst(uint8_t *pbuf, uint16_t len)
 
 static void spi_cris_enter(void)
 {
-    rt_enter_critical();
+    rt_spi_take_bus(wiz_device);
 }
 
 static void spi_cris_exit(void)
 {
-    rt_exit_critical();
+    rt_spi_release_bus(wiz_device);
 }
 
 static void spi_cs_select(void)


### PR DESCRIPTION
修复在 ping 域名失败之后再 ping ip地址的时候会出现失败的问题。
会出现 "wiz_ping: create ping socket(%d) failed.” 失败提示。