### PR TITLE
补全int wiz_ping()中rt_kprintf的%d参数

### DIFF
--- a/src/wiz_ping.c
+++ b/src/wiz_ping.c
@@ -207,7 +207,7 @@ int wiz_ping(struct netdev *netdev, const char *host, size_t data_len, uint32_t 
     socket = wiz_socket(AF_WIZ, SOCK_RAW, 0);
     if (socket < 0)
     {
-        rt_kprintf("wiz_ping: create ping socket(%d) failed.\n");
+        rt_kprintf("wiz_ping: create ping socket(%d) failed.\n",socket);
         return -1;
     }
     /* set socket ICMP protocol */

--- a/src/wiz_socket.c
+++ b/src/wiz_socket.c
@@ -1438,6 +1438,7 @@ struct hostent *wiz_gethostbyname(const char *name)
     static ip_addr_t s_hostent_addr;
     static ip_addr_t *s_phostent_addr[2];
     static char s_hostname[DNS_MAX_NAME_LENGTH + 1];
+    struct wiz_socket *sock = RT_NULL;
     size_t idx = 0;
 
     /* check WIZnet initialize status */
@@ -1463,8 +1464,9 @@ struct hostent *wiz_gethostbyname(const char *name)
         uint8_t dns_ip[4] = {114, 114, 114, 114};
         uint8_t data_buffer[512];
 
-        for (idx = 0; idx < WIZ_SOCKETS_NUM && sockets[idx].magic; idx++);
-        if (idx >= WIZ_SOCKETS_NUM)
+        /* allocate and initialize a new WIZnet socket */
+        sock = alloc_socket();
+        if (sock == RT_NULL)
         {
             LOG_E("WIZnet DNS failed, socket number is full.");
             return RT_NULL;
@@ -1474,6 +1476,7 @@ struct hostent *wiz_gethostbyname(const char *name)
         DNS_init(idx, data_buffer);
         /* DNS client processing */
         ret = DNS_run(dns_ip, (uint8_t *)name, remote_ip);
+        free_socket(sock);
         if (ret == -1)
         {
             LOG_E("WIZnet MAX_DOMAIN_NAME is too small, should be redefined it.");


### PR DESCRIPTION
补全src/wiz_ping.c中int wiz_ping()中rt_kprintf的%d参数；
修改src/wiz_socket.c中为DNS申请分配Socket时，调用alloc_socket函数，在DNS_run后使用free_socket对Socket释放，避免使用wiz_socket()时因为sockets[idx].magic无值而造成Socket被重复使用。