### PR TITLE
[fix] DHCP，ARP，DNS_SERVER

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ msh />wiz_ping baidu.com
 
 - WIZnet 软件包最新版本已支持作为 server 服务器模式（V1.1.0 版本之前不支持）。
 
-- WIZNet 软件包初始化出现 ```[E/wiz.dev] You should attach [wiznet] into SPI bus firstly.```错误，是因为没有挂在 winzet 设备到 SPI 总线导致的；请参考 wiz_init 函数中的注释，解决软件包初始化失败的问题。
+- WIZNet 软件包初始化出现 ```[E/wiz.dev] You should attach [wiznet] into SPI bus firstly.```错误，是因为没有挂载 winzet 设备到 SPI 总线导致的；请参考 wiz_init 函数中的注释，解决软件包初始化失败的问题。
 
 
 ## 5、注意事项

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ WIZnet 软件包遵循 Apache-2.0 许可，详见 LICENSE 文件。
 
 ## 2、获取软件包
 
-使用 WIZnet 软件包需要在 RT-Thread 的包管理中选中它，具体路径如下： 
+使用 WIZnet 软件包需要在 RT-Thread 的包管理中选中它，具体路径如下：
 
 ```shell
 WIZnet: WIZnet TCP/IP chips SAL framework implement
@@ -59,7 +59,7 @@ WIZnet: WIZnet TCP/IP chips SAL framework implement
                 (192.168.1.10) IPv4: IP address
                 (192.168.1.1) IPv4: Gateway address
                 (255.255.255.0) IPv4: Mask address
-  [ ]   Enable Ping utility             
+  [ ]   Enable Ping utility
   [ ]   Enable debug log output
         Version (latest)  --->
 ```
@@ -140,18 +140,19 @@ msh />wiz_ping baidu.com
 - SPI 设备初始化时断言问题
 
   ```shell
-  (wiz_device->parent.type == RT_Device_Class_SPIDevice) assertion failed at function:wiz_spi_init, line number:126 
+  (wiz_device->parent.type == RT_Device_Class_SPIDevice) assertion failed at function:wiz_spi_init, line number:126
   ```
 
-  出现上述断言问题，可能原因是 ENV 中配置 WIZnet 使用的 SPI 设备类型不正确，可以在添加 WIZnet 软件包之前在 FinSH 中使用 `list_device` 查看当前可用 SPI 设备名称，如果 BSP 工程中没有 SPI 设备或者只有 SPI 总线设备，需要手动在驱动中添加 SPI 设备，并正确配置 WIZnet 软件包中使用的 SPI 设备名称。
+  出现上述断言问题，可能原因是 ENV 中配置 WIZnet 使用的 SPI 设备名称填写不正确，请区分 SPI DEVICE 与 SPI BUS 的关系。如果 BSP 工程中没有 SPI 设备或者只有 SPI 总线设备，需要手动在驱动中挂载 SPI 设备到SPI 总线，并正确配置 WIZnet 软件包中使用的 SPI 设备名称。
 
 - WIZnet 软件包最新版本已支持作为 server 服务器模式（V1.1.0 版本之前不支持）。
+
+- WIZNet 软件包初始化出现 ```[E/wiz.dev] You should attach [wiznet] into SPI bus firstly.```错误，请先参考 wiz_init 函数中的注释，解决软件包初始化失败的问题。
 
 
 ## 5、注意事项
 
 - 获取软件包时，需要注意正确配置使用的 SPI 设备名称、复位引脚号和中断引脚号；
-
 - 初始化完成之后，建议使用 `wiz_set_mac()` 函数设置设备 MAC 地址，防止使用默认 MAC 地址产生冲突；
 
 ## 6、联系方式 & 感谢

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ msh />wiz_ping baidu.com
   (wiz_device->parent.type == RT_Device_Class_SPIDevice) assertion failed at function:wiz_spi_init, line number:126
   ```
 
-  出现上述断言问题，可能原因是 ENV 中配置 WIZnet 使用的 SPI 设备名称填写不正确，请区分 SPI DEVICE 与 SPI BUS 的关系。如果 BSP 工程中没有 SPI 设备或者只有 SPI 总线设备，需要手动在驱动中挂载 SPI 设备到SPI 总线，并正确配置 WIZnet 软件包中使用的 SPI 设备名称。
+  出现上述断言问题，可能原因是 ENV 中配置 WIZnet 使用的 SPI 设备名称填写不正确，请区分 SPI DEVICE 与 SPI BUS 的关系。如果 BSP 工程中没有 SPI 设备或者只有 SPI 总线设备，需要手动在驱动中挂载 SPI 设备到 SPI 总线，并正确配置 WIZnet 软件包中使用的 SPI 设备名称。
 
 - WIZnet 软件包最新版本已支持作为 server 服务器模式（V1.1.0 版本之前不支持）。
 
-- WIZNet 软件包初始化出现 ```[E/wiz.dev] You should attach [wiznet] into SPI bus firstly.```错误，请先参考 wiz_init 函数中的注释，解决软件包初始化失败的问题。
+- WIZNet 软件包初始化出现 ```[E/wiz.dev] You should attach [wiznet] into SPI bus firstly.```错误，是因为没有挂在 winzet 设备到 SPI 总线导致的；请参考 wiz_init 函数中的注释，解决软件包初始化失败的问题。
 
 
 ## 5、注意事项

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -47,7 +47,7 @@
 #define WIZ_ID_LEN                     6
 static char wiz_netdev_name[WIZ_ID_LEN];
 
-#define WIZ_DHCP_SOCKET				   7
+#define WIZ_DHCP_SOCKET                7
 
 extern struct rt_spi_device *wiz_device;
 extern int wiz_device_init(const char *spi_dev_name, rt_base_t rst_pin, rt_base_t isr_pin);
@@ -213,7 +213,7 @@ static void wiz_ip_assign(void)
     getDNSfromDHCP(wiz_net_info.dns);
     wiz_net_info.dhcp = NETINFO_DHCP;
 
-    ctlnetwork(CN_SET_NETINFO, (void*) &wiz_net_info);   
+    ctlnetwork(CN_SET_NETINFO, (void*) &wiz_net_info);
 }
 
 static void wiz_ip_conflict(void)
@@ -293,22 +293,22 @@ static int wiz_netstr_to_array(const char *net_str, uint8_t *net_array)
 /* set WIZnet device MAC address */
 RT_WEAK void wiz_user_config_mac(char *mac_buf, rt_uint8_t buf_len)
 {
-	RT_ASSERT(mac_buf != RT_NULL);
-	RT_ASSERT(buf_len > 0);
-	
-	rt_memset(mac_buf, 0x0, buf_len);
-	rt_strncpy(mac_buf, WIZ_DEFAULT_MAC, buf_len);
+    RT_ASSERT(mac_buf != RT_NULL);
+    RT_ASSERT(buf_len > 0);
+
+    rt_memset(mac_buf, 0x0, buf_len);
+    rt_strncpy(mac_buf, WIZ_DEFAULT_MAC, buf_len);
 }
 
 static void wiz_set_mac(void)
 {
-	char mac_str[32];
-	
-	wiz_user_config_mac(mac_str, sizeof(mac_str));
-	if (wiz_netstr_to_array(mac_str, wiz_net_info.mac) != RT_EOK)
-	{
-		wiz_netstr_to_array(WIZ_DEFAULT_MAC, wiz_net_info.mac);
-	}
+    char mac_str[32];
+
+    wiz_user_config_mac(mac_str, sizeof(mac_str));
+    if (wiz_netstr_to_array(mac_str, wiz_net_info.mac) != RT_EOK)
+    {
+        wiz_netstr_to_array(WIZ_DEFAULT_MAC, wiz_net_info.mac);
+    }
 }
 
 static int wiz_network_dhcp(struct netdev *netdev);
@@ -336,13 +336,13 @@ static int wiz_network_init(rt_bool_t b_config)
     wiz_net_info.dhcp = NETINFO_STATIC;
 #endif
 
-	int result = RT_EOK;
-	rt_bool_t b_status = b_config;
-	
-	/* set mac information */
-	wiz_set_mac();
+    int result = RT_EOK;
+    rt_bool_t b_status = b_config;
+
+    /* set mac information */
+    wiz_set_mac();
     /* set static WIZnet network information */
-    ctlnetwork(CN_SET_NETINFO, (void*) &wiz_net_info);	
+    ctlnetwork(CN_SET_NETINFO, (void*) &wiz_net_info);
 
 #ifdef WIZ_USING_DHCP
     /* alloc IP address through DHCP */
@@ -350,14 +350,14 @@ static int wiz_network_init(rt_bool_t b_config)
         result = wiz_network_dhcp(netdev);
         if (result != RT_EOK)
         {
-        	b_status = RT_FALSE;
-            LOG_E("WIZnet network initialize failed, DHCP timeout.");			
+            b_status = RT_FALSE;
+            LOG_E("WIZnet network initialize failed, DHCP timeout.");
         }
-		else
-		{
-			b_status = RT_TRUE;
-			LOG_D("WIZnet network initialize success.");	
-		}
+        else
+        {
+            b_status = RT_TRUE;
+            LOG_D("WIZnet network initialize success.");
+        }
     }
 #endif
 
@@ -392,7 +392,7 @@ static int wiz_socket_init(void)
     return RT_EOK;
 }
 
-static void wiz_dns_time_handler(void* arg)
+static void wiz_dns_time_handler(void *arg)
 {
     extern void DNS_time_handler(void);
     DNS_time_handler();
@@ -577,21 +577,21 @@ static struct netdev *wiz_netdev_add(const char *netdev_name)
 #ifdef WIZ_USING_DHCP
 static void wiz_dhcp_work(struct rt_work *dhcp_work, void *dhcp_work_data)
 {
-#define WIZ_DHCP_WORK_RETRY 		1
-#define WIZ_DHCP_WORK_RETRY_TIME	(2 * RT_TICK_PER_SECOND)
-	
-	RT_ASSERT(dhcp_work_data != RT_NULL);
+#define WIZ_DHCP_WORK_RETRY         1
+#define WIZ_DHCP_WORK_RETRY_TIME    (2 * RT_TICK_PER_SECOND)
 
-	struct netdev *netdev = (struct netdev *)dhcp_work_data;	
-		
-	uint8_t dhcp_times = 0;
-	uint8_t data_buffer[1024];
-	uint32_t dhcp_status = 0;
-	
-	rt_timer_start(dhcp_timer);
+    RT_ASSERT(dhcp_work_data != RT_NULL);
+
+    struct netdev *netdev = (struct netdev *)dhcp_work_data;
+
+    uint8_t dhcp_times = 0;
+    uint8_t data_buffer[1024];
+    uint32_t dhcp_status = 0;
+
+    rt_timer_start(dhcp_timer);
     DHCP_init(WIZ_DHCP_SOCKET, data_buffer);
 
-	while (1)
+    while (1)
     {
         /* DHCP start, return DHCP_IP_LEASED is success. */
         dhcp_status = DHCP_run();
@@ -624,26 +624,26 @@ static void wiz_dhcp_work(struct rt_work *dhcp_work, void *dhcp_work_data)
             dhcp_times++;
             break;
         }
-		case DHCP_STOPPED:
-		{
-			dhcp_times = WIZ_DHCP_WORK_RETRY;
-			break;
-		}
+        case DHCP_STOPPED:
+        {
+            dhcp_times = WIZ_DHCP_WORK_RETRY;
+            break;
+        }
         default:
             break;
         }
-		
+
         if (dhcp_times >= WIZ_DHCP_WORK_RETRY)
         {
             DHCP_stop();
             rt_timer_stop(dhcp_timer);
 
-			if (dhcp_work)
-			{
-				/* according to WIZ_DHCP_WORK_RETRY_TIME, config reconfig after 2 secs */
-				rt_work_init(dhcp_work, wiz_dhcp_work, (void *)netdev);
-				rt_work_submit(dhcp_work, WIZ_DHCP_WORK_RETRY_TIME); 
-			}
+            if (dhcp_work)
+            {
+                /* according to WIZ_DHCP_WORK_RETRY_TIME, config reconfig after 2 secs */
+                rt_work_init(dhcp_work, wiz_dhcp_work, (void *)netdev);
+                rt_work_submit(dhcp_work, WIZ_DHCP_WORK_RETRY_TIME);
+            }
             break;
         }
     }
@@ -651,27 +651,27 @@ static void wiz_dhcp_work(struct rt_work *dhcp_work, void *dhcp_work_data)
 
 static int wiz_network_dhcp(struct netdev *netdev)
 {
-	if (netdev == RT_NULL)
-		return -RT_EINVAL;
-	
-	/* set default MAC address for DHCP */
+    if (netdev == RT_NULL)
+        return -RT_EINVAL;
+
+    /* set default MAC address for DHCP */
     setSHAR(wiz_net_info.mac);
     /* DHCP configure initialize, clear information other than MAC address */
     setSn_RXBUF_SIZE(WIZ_DHCP_SOCKET, 0x02);
     setSn_TXBUF_SIZE(WIZ_DHCP_SOCKET, 0x02);
-	/* register to assign IP address and conflict callback */
+    /* register to assign IP address and conflict callback */
     reg_dhcp_cbfunc(wiz_ip_assign, wiz_ip_assign, wiz_ip_conflict);
 
-	dhcp_timer = rt_timer_create("wiz_dhcp", wiz_dhcp_timer_entry, RT_NULL, 1 * RT_TICK_PER_SECOND, RT_TIMER_FLAG_PERIODIC);
+    dhcp_timer = rt_timer_create("wiz_dhcp", wiz_dhcp_timer_entry, RT_NULL, 1 * RT_TICK_PER_SECOND, RT_TIMER_FLAG_PERIODIC);
     if (dhcp_timer == RT_NULL)
         return -RT_ERROR;
 
-	struct rt_work *dhcp_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
-	if (dhcp_work == RT_NULL)
-		return -RT_ENOMEM;
-	
-	wiz_dhcp_work(dhcp_work, netdev);
-	return RT_EOK;
+    struct rt_work *dhcp_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
+    if (dhcp_work == RT_NULL)
+        return -RT_ENOMEM;
+
+    wiz_dhcp_work(dhcp_work, netdev);
+    return RT_EOK;
 }
 #endif /* WIZ_USING_DHCP */
 
@@ -700,8 +700,8 @@ static void wiz_link_status_thread_entry(void *parameter)
             if (phycfgr & WIZ_PHYCFGR_LINK_STATUS)
             {
 #ifdef WIZ_USING_DHCP
-				wiz_dhcp_work(RT_NULL, netdev);
-#endif				
+                wiz_dhcp_work(RT_NULL, netdev);
+#endif
                 netdev_low_level_set_link_status(netdev, phycfgr & WIZ_PHYCFGR_LINK_STATUS);
                 wiz_netdev_info_update(netdev);
                 LOG_I("%s netdev link status becomes link up", wiz_netdev_name);
@@ -744,7 +744,7 @@ int wiz_init(void)
     wiz_reset();
     /* set WIZnet device read/write data callback */
     wiz_callback_register();
-    /* WIZnet chip configure initialize */	
+    /* WIZnet chip configure initialize */
     result = wiz_chip_cfg_init();
     if (result != RT_EOK)
     {
@@ -759,7 +759,7 @@ int wiz_init(void)
     /* WIZnet socket initialize */
     wiz_socket_init();
 
-    dns_tick_timer = rt_timer_create("dns_tick", wiz_dns_time_handler, RT_NULL, 1*RT_TICK_PER_SECOND, RT_TIMER_FLAG_SOFT_TIMER|RT_TIMER_FLAG_PERIODIC);
+    dns_tick_timer = rt_timer_create("dns_tick", wiz_dns_time_handler, RT_NULL, 1 * RT_TICK_PER_SECOND, RT_TIMER_FLAG_SOFT_TIMER | RT_TIMER_FLAG_PERIODIC);
     rt_timer_start(dns_tick_timer);
 
     /* create WIZnet link status Polling thread  */

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -727,6 +727,7 @@ static void wiz_link_status_thread_entry(void *parameter)
     }
 }
 
+/* #include "stm32f4xx_hal.h" */
 /* WIZnet initialize device and network */
 int wiz_init(void)
 {
@@ -739,6 +740,9 @@ int wiz_init(void)
         LOG_I("RT-Thread WIZnet package is already initialized.");
         return RT_EOK;
     }
+
+    /* I think you can attach w5500 into spi bus at here. You can use this function to realize.*/
+    /* extern rt_err_t rt_hw_spi_device_attach(const char *bus_name, const char *device_name, GPIO_TypeDef *cs_gpiox, uint16_t cs_gpio_pin); */
 
     /* WIZnet SPI device and pin initialize */
     result = wiz_device_init(WIZ_SPI_DEVICE, WIZ_RST_PIN, WIZ_IRQ_PIN);

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -621,12 +621,12 @@ static void wiz_dhcp_work(struct rt_work *dhcp_work, void *dhcp_work_data)
             rt_timer_stop(dhcp_timer);
             /* to update netdev information */
             wiz_netdev_info_update(netdev, RT_FALSE);
-			if (dhcp_work)
-			{
-				/* according to leaset time, config next DHCP produce */
-				rt_work_init(dhcp_work, wiz_dhcp_work, (void *)netdev);
-	    		rt_work_submit(dhcp_work, (getDHCPLeasetime() - 60) * RT_TICK_PER_SECOND); 
-			}
+            if (dhcp_work)
+            {
+                /* according to the DHCP leaset time, config next DHCP produce */
+                rt_work_init(dhcp_work, wiz_dhcp_work, (void *)netdev);
+                rt_work_submit(dhcp_work, (getDHCPLeasetime() / 2) * RT_TICK_PER_SECOND);
+            }
             return;
         }
         case DHCP_FAILED:

--- a/src/wiz_device.c
+++ b/src/wiz_device.c
@@ -119,7 +119,7 @@ static int wiz_spi_init(const char *spi_dev_name)
     wiz_device = (struct rt_spi_device *) rt_device_find(spi_dev_name);
     if (wiz_device == RT_NULL)
     {
-        LOG_E("WIZnet SPI device %s not found!", spi_dev_name);
+        LOG_E("You should attach [%s] into SPI bus firstly.", spi_dev_name);
         return -RT_ENOSYS;
     }
 


### PR DESCRIPTION
* DHCP 现在可以自动续约，但是功能依赖 workqueue。
* ARP 请求已自动发出，路由器可以看到已经获取到 IP 的 WIZNET。
* 获取域名转 IP 地址的默认 DNS 由 114 更改为 WIZNET 获取的 DNS 地址。
* 取消 alloc_socket 使用，测试中出现会引起系统进入 MNI 中断。
* 修改了文本格式，tab 与 whitespace 混用情况已经消除。