### PR TITLE
[HUST_CSE]Close the TCP connection in the fourth wave(wiznet/src/wiz_socket.c#L206#L514)

### DIFF
--- a/src/wiz_socket.c
+++ b/src/wiz_socket.c
@@ -203,7 +203,12 @@ int wiz_closed_notice_cb(int socket)
         return -1;
     }
 
-    if (wizchip_close(socket) != SOCK_OK)
+    int8_t res;
+    if(sock->type == Sn_MR_TCP)
+        res = wizchip_disconnect(socket);
+    else 
+        res = wizchip_close(socket);
+    if (res != SOCK_OK)
     {
         LOG_E("WIZnet socket(%d) close failed.", socket);
         return -1;
@@ -511,7 +516,13 @@ int wiz_closesocket(int socket)
         return -1;
     }
 
-    if (wizchip_close(socket) != SOCK_OK)
+     int8_t res;
+    if(sock->type == Sn_MR_TCP)
+        res = wizchip_disconnect(socket);
+    else 
+        res = wizchip_close(socket);
+        
+    if ( res != SOCK_OK)
     {
         LOG_E("WIZnet socket(%d) close failed.", socket);
         free_socket(sock);


### PR DESCRIPTION
#### 为什么提交这份PR(why to submit this PR)
[issue的地址](https://club.rt-thread.org/ask/question/e3d760fec734c23e.html)
在<b>FTP</b>协议中数据连接是：通过关闭连接动作被客户感知到操作完毕的。</br>
根据W5500的操作手册下的说明：
![ ](https://camo.githubusercontent.com/c14b788742ff0e710b8268e9019ba5fe513bbba02df71a78838f6d9d60265273/68747470733a2f2f6f73732d636c75622e72742d7468726561642e6f72672f75706c6f6164732f32303232303830322f66663662613634323961643636343162643237633730613466363262663234372e706e672e77656270)
W5500进行四次握手后必须关闭Sn_CR寄存器DICON位，直接设置CLOSE位会使
Sn_SR改为SOCK_CLOSED,不再执行FIN/ACK断开机制，导致TCP连接没有完全断开。
这会使得对<b>流程有要求的协议</b>如FTP出现问题。
#### 你的解决方案是什么 (what is your solution)
当需要断开TCP连接时：
我们就设置寄存器为DISCON位，需要调用wizchip_disconnect函数；
而在执行其他功能时候，任然调用wizchip_close函数

#### 在什么测试环境下测试通过 (what is the test environment)</br>
ALL