### PR TITLE
fix: 修复取wiz_socket数据错误

### DIFF
--- a/src/wiz_af_inet.c
+++ b/src/wiz_af_inet.c
@@ -38,7 +38,7 @@ static int wiz_poll(struct dfs_fd *file, struct rt_pollreq *req)
         return -1;
     }
 
-    sock = wiz_get_socket((int)sal_sock->user_data);
+    sock = (struct wiz_socket *)sal_sock->user_data;
     if (sock != NULL)
     {
         rt_base_t level;


### PR DESCRIPTION
`sal_sock->user_data` 存的就已经是`struct wiz_socket *` 数据了