### PR TITLE
解决rtt v5.0.1以上版本报错，dfs_file结构体名字替换以及wiz_socket_ops结构体新增成员导致对不齐的问题

### DIFF
--- a/src/wiz_af_inet.c
+++ b/src/wiz_af_inet.c
@@ -26,7 +26,11 @@
 #endif
 
 #ifdef SAL_USING_POSIX
+  #if (RT_VER_NUM >= 0x50100)
+static int wiz_poll(struct dfs_file *file, struct rt_pollreq *req)
+  #else
 static int wiz_poll(struct dfs_fd *file, struct rt_pollreq *req)
+  #endif
 {
     int mask = 0;
     struct wiz_socket *sock;
@@ -67,22 +71,22 @@ static int wiz_poll(struct dfs_fd *file, struct rt_pollreq *req)
 
 static const struct sal_socket_ops wiz_socket_ops =
 {
-    wiz_socket,
-    wiz_closesocket,
-    wiz_bind,
-    wiz_listen,
-    wiz_connect,
-    wiz_accept,
-    wiz_sendto,
-    wiz_recvfrom,
-    wiz_getsockopt,
-    wiz_setsockopt,
-    wiz_shutdown,
-    NULL,
-    NULL,
-    NULL,
+    .socket         = wiz_socket,
+    .closesocket    = wiz_closesocket,
+    .bind           = wiz_bind,
+    .listen         = wiz_listen,
+    .connect        = wiz_connect,
+    .accept         = wiz_accept,
+    .sendto         = wiz_sendto,
+    .recvfrom       = wiz_recvfrom,
+    .getsockopt     = wiz_getsockopt,
+    .setsockopt     = wiz_setsockopt,
+    .shutdown       = wiz_shutdown,
+    .getpeername    = NULL,
+    .getsockname    = NULL,
+    .ioctlsocket    = NULL,
 #ifdef SAL_USING_POSIX
-    wiz_poll,
+    .poll           = wiz_poll,
 #endif /* SAL_USING_POSIX */
 };
 


### PR DESCRIPTION
我在v5.2.0环境下测试通过。

1、rtt v5.0.1以上版本dfs_fd结构体竟然把名字改了没有任何适配；
![image](https://github.com/user-attachments/assets/ee402772-f28a-4879-9c8d-ffb29f84b4ab)

2、同样改版本sal_socket_ops结构体中间插入了新成员，这种初始化的方式导致结构成员对不齐，导致编译通过但是取到的数据是错误的，一直timeout.

这是rtt v5.2.0环境下运行：
![image](https://github.com/user-attachments/assets/4fbeca45-3141-483a-8ba2-db6da06f9377)
