### PR TITLE
fix wiznet build

### DIFF
--- a/ioLibrary/Ethernet/W5500/w5500.h
+++ b/ioLibrary/Ethernet/W5500/w5500.h
@@ -913,18 +913,6 @@ extern "C" {
  */
 #define Sn_MR_MC                     Sn_MR_ND
 
-/* Sn_MR alternate values */
-/**
- * @brief For Berkeley Socket API
- */
-#define SOCK_STREAM                  Sn_MR_TCP
-
-/**
- * @brief For Berkeley Socket API
- */
-#define SOCK_DGRAM                   Sn_MR_UDP
-
-
 /* Sn_CR values */
 /**
  * @brief Initialize or open socket

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -619,7 +619,11 @@ static int wiz_netdev_set_dhcp(struct netdev *netdev, rt_bool_t is_enabled)
 }
 
 #ifdef RT_USING_FINSH
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
+static int wiz_netdev_ping(struct netdev *netdev, const char *host, size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp, rt_bool_t isbind)
+#else 
 static int wiz_netdev_ping(struct netdev *netdev, const char *host, size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp)
+#endif
 {
     RT_ASSERT(netdev);
     RT_ASSERT(host);

--- a/src/wiz_af_inet.c
+++ b/src/wiz_af_inet.c
@@ -26,7 +26,12 @@
 #endif
 
 #ifdef SAL_USING_POSIX
-static int wiz_poll(struct dfs_fd *file, struct rt_pollreq *req)
+
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 1))
+static int wiz_poll(struct dfs_file  *file, struct rt_pollreq *req)
+#else
+static int wiz_poll(struct dfs_fd  *file, struct rt_pollreq *req)
+#endif
 {
     int mask = 0;
     struct wiz_socket *sock;
@@ -74,6 +79,10 @@ static const struct sal_socket_ops wiz_socket_ops =
     wiz_connect,
     wiz_accept,
     wiz_sendto,
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
+    NULL,
+    NULL,
+#endif
     wiz_recvfrom,
     wiz_getsockopt,
     wiz_setsockopt,
@@ -81,6 +90,9 @@ static const struct sal_socket_ops wiz_socket_ops =
     NULL,
     NULL,
     NULL,
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
+    NULL,
+#endif
 #ifdef SAL_USING_POSIX
     wiz_poll,
 #endif /* SAL_USING_POSIX */


### PR DESCRIPTION
修复wiznet编译问题，适配高版本
https://github.com/RT-Thread/rt-thread/issues/9526

合并此pr必须先合并https://github.com/RT-Thread/packages/pull/1834


bsp:stm32\stm32f103-atk-warshipv3


编译结果：
![Clip_2024-12-18_20-25-17](https://github.com/user-attachments/assets/de73511e-9890-410f-b08a-68aeeb364991)

运行结果：
![Clip_2024-12-18_20-25-55](https://github.com/user-attachments/assets/f6d33c58-3b13-4b88-9926-a43555990567)
